### PR TITLE
fix integration test bean

### DIFF
--- a/src/test/java/org/springframework/samples/petclinic/BaseIntegrationTest.java
+++ b/src/test/java/org/springframework/samples/petclinic/BaseIntegrationTest.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2012-2024 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.samples.petclinic;
+
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.azure.ai.openai.OpenAIClient;
+
+@ActiveProfiles("test")
+public class BaseIntegrationTest {
+
+	@MockBean
+	private OpenAIClient openAIClient;
+
+}

--- a/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/MySqlIntegrationTests.java
@@ -41,11 +41,11 @@ import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@ActiveProfiles({ "mysql", "test" })
+@ActiveProfiles("mysql")
 @Testcontainers(disabledWithoutDocker = true)
 @DisabledInNativeImage
 @DisabledInAotMode
-class MySqlIntegrationTests {
+class MySqlIntegrationTests extends BaseIntegrationTest {
 
 	@ServiceConnection
 	@Container

--- a/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PetClinicIntegrationTests.java
@@ -28,12 +28,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
 import org.springframework.samples.petclinic.vet.VetRepository;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@ActiveProfiles("test")
-public class PetClinicIntegrationTests {
+public class PetClinicIntegrationTests extends BaseIntegrationTest {
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/PostgresIntegrationTests.java
@@ -47,9 +47,9 @@ import org.testcontainers.DockerClientFactory;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT,
 		properties = { "spring.docker.compose.skip.in-tests=false", "spring.docker.compose.profiles.active=postgres" })
-@ActiveProfiles({ "postgres", "test" })
+@ActiveProfiles("postgres")
 @DisabledInNativeImage
-public class PostgresIntegrationTests {
+public class PostgresIntegrationTests extends BaseIntegrationTest {
 
 	@LocalServerPort
 	int port;

--- a/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
+++ b/src/test/java/org/springframework/samples/petclinic/system/CrashControllerIntegrationTests.java
@@ -36,8 +36,8 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.samples.petclinic.BaseIntegrationTest;
 import org.springframework.samples.petclinic.PetClinicApplication;
-import org.springframework.test.context.ActiveProfiles;
 
 /**
  * Integration Test for {@link CrashController}.
@@ -47,8 +47,7 @@ import org.springframework.test.context.ActiveProfiles;
 // NOT Waiting https://github.com/spring-projects/spring-boot/issues/5574
 @SpringBootTest(webEnvironment = RANDOM_PORT,
 		properties = { "server.error.include-message=ALWAYS", "management.endpoints.enabled-by-default=false" })
-@ActiveProfiles("test")
-class CrashControllerIntegrationTests {
+class CrashControllerIntegrationTests extends BaseIntegrationTest {
 
 	public static void main(String[] args) {
 		SpringApplication.run(PetClinicApplication.class, args);


### PR DESCRIPTION
When the openai endpoint & key are empty, the integration test will throw errors like:

BeanInstantiationException: Failed to instantiate [com.azure.ai.openai.OpenAIClient]: Factory method 'openAIClient' threw exception with message: Either API key or OpenAI API key must not be empty

Mock a OpenAIClient bean to fix this. 